### PR TITLE
Bugfix/styling fixes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -490,10 +490,10 @@ add_theme_support( 'editor-font-sizes', array(
 		'slug'      => 'small'
 	),
 	array(
-		'name'      => __( 'Regular', 'miles_2020' ),
+		'name'      => __( 'Medium', 'miles_2020' ),
 		'shortName' => __( 'M', 'miles_2020' ),
 		'size'      => 20,
-		'slug'      => 'regular'
+		'slug'      => 'medium'
 	),
 	array(
 		'name'      => __( 'Large', 'miles_2020' ),
@@ -501,7 +501,6 @@ add_theme_support( 'editor-font-sizes', array(
 		'size'      => 24,
 		'slug'      => 'large'
 	),
-
 ) );
 
 add_theme_support( 'disable-custom-font-sizes' );

--- a/functions.php
+++ b/functions.php
@@ -400,6 +400,26 @@ add_theme_support( 'editor-color-palette', array(
 add_filter( 'wprss_ftp_link_post_title', '__return_true' );
 
 /**
+ * Adjust font sizes
+ */
+function adjust_font_sizes( $settings ) {
+    if ( isset( $settings['fontSizes'] ) && is_array( $settings['fontSizes'] ) ) {
+        foreach ( $settings['fontSizes'] as &$font_size ) {
+            if ( 'medium' === $font_size['slug'] ) {
+                $font_size['size'] = 18;
+            }
+			if ( 'large' === $font_size['slug'] ) {
+                $font_size['size'] = 20;
+            }
+        }
+    }
+    return $settings;
+}
+add_filter( 'block_editor_settings_all', 'adjust_font_sizes' );
+
+
+
+/**
  * Register Custom Blocks 
  *
  */
@@ -492,15 +512,16 @@ add_theme_support( 'editor-font-sizes', array(
 	array(
 		'name'      => __( 'Medium', 'miles_2020' ),
 		'shortName' => __( 'M', 'miles_2020' ),
-		'size'      => 20,
+		'size'      => 18,
 		'slug'      => 'medium'
 	),
 	array(
 		'name'      => __( 'Large', 'miles_2020' ),
 		'shortName' => __( 'L', 'miles_2020' ),
-		'size'      => 24,
+		'size'      => 20,
 		'slug'      => 'large'
 	),
 ) );
+
 
 add_theme_support( 'disable-custom-font-sizes' );

--- a/index.php
+++ b/index.php
@@ -49,16 +49,14 @@ get_header();
 
 			?>
             </section>
+			<section class="blog-pagination"> 
+                <?php
+				the_posts_navigation();
+                ?>
+            </section>
             <section>
                 <?php echo shortcode_podcast_teaser() ?>
             </section>
-            <section class="blog-pagination">
-                <?php
-                the_posts_navigation();
-                ?>
-            </section>
-
-
             <?php
 
 		else :

--- a/style.css
+++ b/style.css
@@ -2261,10 +2261,6 @@ Other menus
 /******** Blocks core ******/
 /* Button
 --------------------------------------------- */
-/* line 7, sass/blocks/_core-blocks.scss */
-.wp-block-button {
-    margin: 28px auto !important;
-}
 
 /* line 11, sass/blocks/_core-blocks.scss */
 .wp-block-button__link {

--- a/style.css
+++ b/style.css
@@ -1560,7 +1560,7 @@ a.fagblogg-thumbnail:hover {
 .comment-navigation .nav-links .nav-previous,
 .posts-navigation .nav-links .nav-previous,
 .post-navigation .nav-links .nav-previous {
-    background: url('image/arrow-back-red-1.svg') no-repeat left center;
+    background: url('image/chevron_left.svg') no-repeat left center;
     background-size: 27px;
     padding-left: 36px;
 }
@@ -1570,7 +1570,7 @@ a.fagblogg-thumbnail:hover {
 .post-navigation .nav-links .nav-next {
     margin-left: auto;
     text-align: right;
-    background: url('image/arrow-next-red.svg') no-repeat right center;
+    background: url('image/chevron_right.svg') no-repeat right center;
     background-size: 27px;
     padding-right: 36px;
 }
@@ -1585,6 +1585,7 @@ a.fagblogg-thumbnail:hover {
 .posts-navigation .nav-links a,
 .post-navigation .nav-links a {
     text-decoration: none;
+    color: var(--miles_secondary_four);
 }
 /* line 97, sass/navigation/_nav-links.scss */
 .comment-navigation .nav-links a:hover,

--- a/style.css
+++ b/style.css
@@ -4241,6 +4241,10 @@ miles-office-banner {
     margin-bottom: 4rem;
 }
 
+.page-vi-er-miles .wp-block-group > .wp-block-group__inner-container:first-child {
+    margin-top: 4rem;
+}
+
 .page-fagomrader .miles-button-row > div {
     flex-wrap: wrap;
     flex-direction: row;

--- a/style.css
+++ b/style.css
@@ -1562,7 +1562,6 @@ a.fagblogg-thumbnail:hover {
 .posts-navigation .nav-links .nav-previous,
 .post-navigation .nav-links .nav-previous {
     background: url('image/chevron_left.svg') no-repeat left center;
-    background-size: 27px;
     padding-left: 36px;
 }
 /* line 84, sass/navigation/_nav-links.scss */
@@ -1572,7 +1571,6 @@ a.fagblogg-thumbnail:hover {
     margin-left: auto;
     text-align: right;
     background: url('image/chevron_right.svg') no-repeat right center;
-    background-size: 27px;
     padding-right: 36px;
 }
 /* line 92, sass/navigation/_nav-links.scss */

--- a/style.css
+++ b/style.css
@@ -554,16 +554,17 @@ h1 {
 h1.entry-title {
     font-weight: 600;
     margin-bottom: 5rem;
+    margin-top: 5rem;
     margin-left: auto;
     margin-right: auto;
-    padding-left: var(--mobile-horizontal-space);
-    padding-right: var(--mobile-horizontal-space);
+    /*padding-left: var(--mobile-horizontal-space);
+    padding-right: var(--mobile-horizontal-space);*/
     width: var(--page-wrap);
 }
 
 @media screen and (min-width: 768px) {
     h1.entry-title {
-        margin-bottom: 10rem;
+        margin-bottom: 4rem;
         width: 100%;
     }
 }
@@ -3362,21 +3363,25 @@ input[type='file']::file-selector-button {
 ****************/
 
 /* line 43, sass/components/_posts-and-pages.scss */
-.single-post .post-thumbnail {
+.single-post .entry-header,
+.single-post .post-thumbnail,
+.single-miles_nyheter .post-thumbnail,
+.single-miles_nyheter .entry-header {
     text-align: center;
-    max-width: 100%;
+    max-width: 66.6666vw;
     margin-left: auto;
     margin-right: auto;
 }
 
-.single-post .entry-header {
+/*.single-post .entry-header,
+.single-miles_nyheter .entry-header {
     text-align: center;
     width: var(--page-wrap);
     margin-left: auto;
     margin-right: auto;
     padding-left: var(--mobile-horizontal-space);
     padding-right: var(--mobile-horizontal-space);
-}
+}*/
 
 /* line 50, sass/components/_posts-and-pages.scss */
 .single-post .entry-header .entry-title,
@@ -3384,13 +3389,22 @@ input[type='file']::file-selector-button {
 .single-post .entry-header .entry-content,
 .single-post .post-thumbnail .entry-title,
 .single-post .post-thumbnail .entry-meta,
-.single-post .post-thumbnail .entry-content {
+.single-post .post-thumbnail .entry-content,
+.single-miles_nyheter .entry-header .entry-title,
+.single-miles_nyheter .entry-header .entry-meta, 
+.single-miles_nyheter .entry-header .entry-content, 
+.single-miles_nyheter .post-thumbnail .entry-title,
+.single-miles_nyheter .post-thumbnail .entry-meta, 
+.single-miles_nyheter .post-thumbnail .entry-content {
     text-align: left;
 }
 /* line 57, sass/components/_posts-and-pages.scss */
 .single-post .entry-meta,
 .single-post .entry-content,
-.single-post .entry-footer {
+.single-post .entry-footer,
+.single-miles_nyheter .entry-meta, 
+.single-miles_nyheter .entry-content, 
+.single-miles_nyheter .entry-footer {
     margin: 28px 14px;
     text-align: left;
 }
@@ -3398,13 +3412,17 @@ input[type='file']::file-selector-button {
     /* line 57, sass/components/_posts-and-pages.scss */
     .single-post .entry-meta,
     .single-post .entry-content,
-    .single-post .entry-footer {
+    .single-post .entry-footer,
+    .single-miles_nyheter .entry-meta, 
+    .single-miles_nyheter .entry-content, 
+    .single-miles_nyheter .entry-footer {
         max-width: calc(calc(var(--content_width) / 3) * 2);
         margin: 42px auto;
     }
 }
 /* line 69, sass/components/_posts-and-pages.scss */
-.single-post .entry-footer {
+.single-post .entry-footer,
+.single-miles_nyheter .entry-footer {
     display: none;
 }
 
@@ -3417,12 +3435,18 @@ footer.entry-footer {
     margin-top: 4rem;
 }
 
-.single-post .entry-meta {
+.single-miles_nyheter h2 {
+    margin-top: 4rem;
+}
+
+.single-post .entry-meta,
+.single-miles_nyheter .entry-meta {
     display: none;
 }
 
 @media (min-width: 768px) {
-    .single-post .wp-block-quote {
+    .single-post .wp-block-quote,
+    .single-miles_nyheter .wp-block-quote {
         display: flex;
         flex-direction: column;
         gap: 2rem;


### PR DESCRIPTION
This PR includes the following changes:

- Right/left arrow icon has been changed to conform with the design.
- Podcast teaser has been moved below the navigation controls on the [Fagblogg](https://www.miles.no/newsite/fagblogg/) page
- Added some top margin to the first image block shown on the [Vi er miles](https://www.miles.no/newsite/vi-er-miles/) page
- Changed from 'regular' to 'medium' for medium font size in the editors font size controls (in WP-Admin) (see https://github.com/miles-no/miles-wp-theme/commit/8578c0409f87be607ce84991df6e0ae46daca7a4)
- Adjusted site-wide font sizes (see https://github.com/miles-no/miles-wp-theme/commit/cb31d2bf791d6339d4050894e723d291ce693f25)
- Tuned styling for blog post pages. This fixes the misaligned header/content issue we have on the 'nyhetssaker' and 'fagblogg' pages (see https://github.com/miles-no/miles-wp-theme/commit/e9f2c5badc989cc1768bca39ada885a71142019d)


Regarding the font sizes, we may need to do some further adjustments and have a discussion with Lukas for some final input. 