### PR TITLE
Custom archive page

### DIFF
--- a/archive-miles_nyheter.php
+++ b/archive-miles_nyheter.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Custom template for the archive page. In practise, this page is used for "News".
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package Miles_2023
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+
+		<?php if ( have_posts() ) : ?>
+
+			<section class="pre-entry-content">
+				<?php
+                $description = get_theme_mod('miles_archive_description');
+                $title = get_theme_mod('miles_archive_title');
+                if( $title ) {
+                    echo '<h1>' . esc_html( $title ) . '</h1>';
+                }
+                if( $description ) {
+                    echo '<p class="has-medium-font-size">' . $description . '</p>';
+                }
+                //the_archive_title( '<h1>', '</h1>' );
+				//the_archive_description( '<p class="has-medium-font-size">', '</p>' );
+				?>
+			</section><!-- .page-header -->
+
+            <section class="blog-grid">
+			<?php
+			/* Start the Loop */
+			while ( have_posts() ) :
+				the_post();
+
+				/*
+				 * Include the Post-Type-specific template for the content.
+				 * If you want to override this in a child theme, then include a file
+				 * called content-___.php (where ___ is the Post Type name) and that will be used instead.
+				 */
+				get_template_part( 'template-parts/content-blog', get_post_type() );
+
+			endwhile;
+        ?>
+        </section>
+        <?php
+		the_posts_navigation();
+
+	else :
+
+		get_template_part( 'template-parts/content-blog', 'none' );
+
+	endif;
+	?>
+
+	</main><!-- #main -->
+
+<?php
+get_sidebar();
+get_footer();

--- a/functions.php
+++ b/functions.php
@@ -498,6 +498,44 @@ function be_register_blocks() {
 }
 add_action('acf/init', 'be_register_blocks' );
 
+//Settings for the "Nyheter" page (archive-miles_nyheter)
+function customizer_miles_archive_settings( $wp_customize ) {
+
+    $wp_customize->add_section( 'miles_archive_section', array(
+        'title'       => __( 'News settings', 'textdomain' ),
+        'priority'    => 30,
+    ) );
+
+     // title
+     $wp_customize->add_setting( 'miles_archive_title', array(
+        'default'           => 'Nyheter',
+        'sanitize_callback' => 'sanitize_text_field',
+    ) );
+
+    // title control
+    $wp_customize->add_control( 'miles_archive_title', array(
+        'label'    => __( 'Title', 'textdomain' ),
+        'section'  => 'miles_archive_section',
+        'type'     => 'text',
+    ) );
+
+    //description
+    $wp_customize->add_setting( 'miles_archive_description', array(
+        'default'     => '',
+        'sanitize_callback' => 'wp_kses_post',
+    ) );
+
+    // description control
+    $wp_customize->add_control( 'miles_archive_description', array(
+        'label'       => __( 'Description', 'textdomain' ),
+        'section'     => 'miles_archive_section',
+        'type'        => 'textarea',
+    ) );
+
+}
+add_action( 'customize_register', 'customizer_miles_archive_settings' );
+
+
 
  
 // Adds support for editor font sizes.

--- a/style.css
+++ b/style.css
@@ -3644,6 +3644,10 @@ footer.entry-footer {
     padding-right: var(--mobile-horizontal-space);
 }
 
+.archive .site-main .pre-entry-content p {
+    padding-bottom: 2rem;
+}
+
 @media (min-width: 1025px) and (max-width: 1472px) {
     .blog .site-main .blog-grid {
         padding-right: var(--legacy-desktop-resolutions-horizontal-space);

--- a/style.css
+++ b/style.css
@@ -3607,7 +3607,6 @@ footer.entry-footer {
 }
 
 /* line 5, sass/components/_archives.scss */
-.archive header,
 .blog > header,
 .blog .latestpodcast {
     width: var(--page-wrap);
@@ -3631,7 +3630,7 @@ footer.entry-footer {
 }
 
 /* line 9, sass/components/_archives.scss */
-.archive .site-main,
+.archive .site-main .blog-grid,
 .blog .site-main .blog-grid {
     margin: auto;
     width: var(--page-wrap);


### PR DESCRIPTION
This PR fixed #47 and includes the following changes and fixes:

- Adds a custom template for the archive page, i.e. what we know as "Nyheter".
- Adds controls in the "customizer" to control the title and description of the page (see image below)
- Fixes an issue where the navbar header wouldn't span the full width of the page

Note that the blog post "cards" are only crammed when the customizer is open. 

<img width="1728" alt="image" src="https://github.com/miles-no/miles-wp-theme/assets/143096204/898b6586-0f79-40d3-82e4-c88bc269f70a">
