### PR TITLE
Text for blog navigation links is changed to Norwegian

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -35,7 +35,12 @@ get_header();
 
 			endwhile;
 
-			the_posts_navigation();
+			the_posts_navigation(
+				array(
+					'prev_text' => __( 'Eldre innlegg' ),
+					'next_text' => __( 'Nyere innlegg' ),
+				)
+			);
 
 		else :
 

--- a/index.php
+++ b/index.php
@@ -50,9 +50,14 @@ get_header();
 			?>
             </section>
 			<section class="blog-pagination"> 
-                <?php
-				the_posts_navigation();
-                ?>
+            	<?php
+					the_posts_navigation(
+						array(
+							'prev_text' => __( 'Eldre innlegg' ),
+							'next_text' => __( 'Nyere innlegg' ),
+						)
+					);
+            	?>
             </section>
             <section>
                 <?php echo shortcode_podcast_teaser() ?>

--- a/search.php
+++ b/search.php
@@ -37,7 +37,12 @@ get_header();
 
 			endwhile;
 
-			the_posts_navigation();
+			the_posts_navigation(
+				array(
+					'prev_text' => __( 'Eldre innlegg' ),
+					'next_text' => __( 'Nyere innlegg' ),
+				)
+			);
 
 		else :
 

--- a/style.css
+++ b/style.css
@@ -1550,10 +1550,14 @@ a.fagblogg-thumbnail:hover {
     margin-left: auto;
 }
 
-.comment-navigation .nav-links a,
+.comment-navigation .nav-links a {
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
 .posts-navigation .nav-links a,
 .post-navigation .nav-links a {
-    font-size: 1rem;
+    font-size: 1.25rem;
     line-height: 1.5;
 }
 


### PR DESCRIPTION
Fixes #53 

Fixes done:
- Older Posts is changed to Eldre innlegg
- Newer Posts is changed to Nyere innlegg
- Text sizes for above mentioned links is made bigger
- When browsing individual blogs, the navigation links shown for adjacent blogs are also made bigger